### PR TITLE
input_check_qced FromPairs 2 fix

### DIFF
--- a/subworkflows/input_check.nf
+++ b/subworkflows/input_check.nf
@@ -77,7 +77,7 @@ workflow input_check_qced {
                 .set { reads }
         } else {
             Channel
-                .fromFilePairs(params.reads, size: params.single_end ? 1 : 3)
+                .fromFilePairs(params.reads, size: params.single_end ? 1 : 2)
                 .ifEmpty { exit 1, "Cannot find any matching reads in ${params.reads}\nPaths must be in enclosed quotes"}
                 .map { row ->
                         def meta = [:]


### PR DESCRIPTION
Fix typo from 3 to 2 to the number of expected files after skipping qc that prevented the pipeline to run when supplying --no_qc after cleaning reads initially